### PR TITLE
Use exec to prevent spawning a new process

### DIFF
--- a/hello-es6
+++ b/hello-es6
@@ -1,4 +1,4 @@
 #!/bin/sh
 rdlkf() { [ -L "$1" ] && (local lk="$(readlink "$1")"; local d="$(dirname "$1")"; cd "$d"; local l="$(rdlkf "$lk")"; ([[ "$l" = /* ]] && echo "$l" || echo "$d/$l")) || echo "$1"; }
 DIR="$(dirname "$(rdlkf "$0")")"
-/usr/bin/env node --harmony "$DIR/hello-es6.js" "$@"
+exec /usr/bin/env node --harmony "$DIR/hello-es6.js" "$@"


### PR DESCRIPTION
I made one little improvement - use the 'exec' shell command to start NodeJS without spawning a new process. Before the patch, you were stuck with two processes (sh and node as a child) forever.